### PR TITLE
Add granularity as a param

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -75,7 +75,8 @@ export default class GnocchiDatasource {
             'aggregation': target.aggregator,
             'start': options.range.from.toISOString(),
             'end': null,
-            'stop': null
+            'stop': null,
+            'granularity': null
           }
         };
         if (options.range.to){
@@ -96,6 +97,7 @@ export default class GnocchiDatasource {
         var resource_id;
         var metric_id;
         var label;
+        var granularity;
 
         try {
           metric_name = self.templateSrv.replace(target.metric_name);
@@ -104,6 +106,7 @@ export default class GnocchiDatasource {
           resource_id = self.templateSrv.replace(target.resource_id);
           metric_id = self.templateSrv.replace(target.metric_id);
           label = self.templateSrv.replace(target.label);
+          granularity = self.templateSrv.replace(target.granularity);
         } catch (err) {
           return self.$q.reject(err);
         }
@@ -119,6 +122,9 @@ export default class GnocchiDatasource {
           return self._gnocchi_request(resource_search_req).then(function(result) {
             return self.$q.all(_.map(result, function(resource) {
               var measures_req = _.merge({}, default_measures_req);
+              if (granularity !== '') {
+                  measures_req.params.granularity = granularity;
+              }
               measures_req.url = ('v1/resource/' + resource_type +
                                   '/' + resource["id"] + '/metric/' + metric_name + '/measures');
               if (!label) { label = "id" ; }

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -37,6 +37,10 @@
             <label class="gf-form-label query-keyword width-8">Metric name</label>
             <input type="text" class="gf-form-input" ng-model="ctrl.target.metric_name" bs-typeahead="ctrl.suggestMetricNames" spellcheck='false' placeholder="metric name" data-min-length=0 ng-model-onblur ng-blur="ctrl.queryUpdated()">
         </div>
+        <div class="gf-form max-width-20" ng-if="['resource', 'resource_search', 'resource_aggregation'].indexOf(ctrl.target.queryMode) >= 0" >
+            <label class="gf-form-label query-keyword width-8">Granularity</label>
+            <input type="text" class="gf-form-input" ng-model="ctrl.target.granularity" spellcheck='false' placeholder="seconds" data-min-length=0 ng-model-onblur ng-blur="ctrl.queryUpdated()">
+        </div>
         <div class="gf-form">
             <label class="gf-form-label query-keyword width-8">Aggregator</label>
             <select ng-model="ctrl.target.aggregator" class="gf-form-input input-small" ng-options="a for a in ctrl.aggregators" ng-change="ctrl.queryUpdated()"> </select>


### PR DESCRIPTION
When looking up a gnocchi datasource without specifying granularity, all the
granularities for a measure are returned. This shows up as multiple points
when viewed on a graph, which can be quite confusing.

Added granularity as a param so that these 'duplicates' don't show up.