### PR TITLE
Added display_name and name to labels

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -106,7 +106,12 @@ var GnocchiDatasource = (function () {
                         if (!label) {
                             label = "id";
                         }
-                        return self._retrieve_measures(resource[label] || "attribute " + label + " not found", measures_req);
+                        var label_str = resource[label] || "attribute " + label + " not found";
+                        var name_str = resource["display_name"] || resource["name"] || "undefined";
+                        if (( name_str !== "undefined" ) && ( label !== "display_name" && label !== "name" )) {
+                            return self._retrieve_measures(label_str + " (" + name_str + ")", measures_req);
+                        }
+                        return self._retrieve_measures(label_str, measures_req);
                     }));
                 });
             }


### PR DESCRIPTION
When a label is added to the legend or data points, it is useful to see a human readable display_name or name as well. For e.g., "uuid (display_name)".